### PR TITLE
Edited infra-types

### DIFF
--- a/doc/infra-types.md
+++ b/doc/infra-types.md
@@ -16,16 +16,9 @@
 | [highway = service]                                       | Access to buildings, beaches, campsites, industrial complexes, etc. [ref](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dservice)                   |
 | [highway = pedestrian]                                    | Road/area mainly/exclusively for pedestrians [ref](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dpedestrian)                                       |
 | [highway = track]                                         | Minor land-access road used for e.g. agriculture or outdoor recreation [ref](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dtrack)                  |
-| [highway = bridleway]                                     | Way intended mostly for horseriders and pedestrians [ref](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dbridleway)                                 |
-| [highway = steps]                                         | Steps on footways or paths [ref](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dsteps)                                                              |
 | [highway = path]                                          | Generic path open to all non-motorized vehicles [ref](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dpath)                                          |
 | [highway = footway]                                       | Minor pathway mainly/exclusively for pedestrians [ref](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dfootway)                                      |
-| [highway = footway]:[bicycle = no]                        | Footway explicitly disallowing bicycles                                                                                                                |
-| [highway = footway]:[bicycle = yes]                       | Footway explicitly allowing bicycles                                                                                                                   |
 | [footway = sidewalk]                                      | Sidewalk [ref](https://wiki.openstreetmap.org/wiki/Tag:footway%3Dsidewalk)                                                                             |
-| [footway = sidewalk]:[bicycle = yes]                      | Sidewalk where bicycles are specifically allowed                                                                                                       |
-| [footway = crossing]                                      | Crossing connecting two footways [ref](https://wiki.openstreetmap.org/wiki/Tag:footway%3Dcrossing)                                                     |
-| [footway = crossing]:[bicycle = yes]                      | Footway crossing specifically to be used by cyclists as well [ref](https://wiki.openstreetmap.org/wiki/Tag:footway%3Dcrossingowing)                    |
 | [highway = cycleway]                                      | Completely seperate (small) way for cyclists [ref](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dcycleway)                                         |
 | [cycleway = lane]                                         | A cycling lane, sharing the road with other vehicles (mostly segregated by paint) [ref](https://wiki.openstreetmap.org/wiki/Tag:cycleway%3Dlane)       |
 | [cycleway = opposite]                                     | One-way-road for normal traffic, bicycles can travel in both directions [ref](https://wiki.openstreetmap.org/wiki/Tag:cycleway%3Dopposite)             |
@@ -37,5 +30,4 @@
 | [bicycle = designated]                                    | Road specifically designated for use by cyclists [ref](https://wiki.openstreetmap.org/wiki/Tag:bicycle%3Ddesignated)                                   |
 | [bicycle_road = yes]                                      | Road prohibiting other vehicles than bicycles unless marked with addition sign [ref](https://wiki.openstreetmap.org/wiki/Key:bicycle_road)             |
 | [busway = lane]                                           | Buslane [ref](https://wiki.openstreetmap.org/wiki/Tag:busway%3Dlane)                                                                                   |
-| [highway = construction]                                  | Highways currently under construction [ref](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dconstruction)                                            |
 

--- a/src/app/calculation/scores.py
+++ b/src/app/calculation/scores.py
@@ -78,14 +78,14 @@ def calculate_scores_infra_types(infra_type, cur, conn):
             f'sum("normalIncidentCount") as incident_count, ' \
             f'round(avg("normalIncidentCount"), 4) as avg_incident_count, ' \
             f'sum("scaryIncidentCount") as scary_incident_count, ' \
-            f'round(avg("scaryIncidentCount"), 4) as avg_scary_incident_count, ' \
+            f'round(avg("scaryIncidentCount" / count), 4) as avg_scary_incident_count, ' \
             f'round(avg("chosenCount"), 4) as avg_c_count, ' \
-            f'round(avg("avoidedCount"), 4) as avg_a_count, ' \
+            f'round(avg("avoidedCount" / count), 4) as avg_a_count, ' \
             f'round(avg(danger_score)) as avg_danger_score, ' \
             f'round(sum("chosenCount")::numeric / (sum("avoidedCount")::numeric + sum("chosenCount")::numeric), 4)::numeric as p_score, ' \
             f'round(greatest(least(1 - (1 / sum(count * (ST_Length(geom::geography)::numeric / 1000))::numeric * (4.4 * sum("scaryIncidentCount")::numeric + sum("normalIncidentCount")::numeric)), 1)::numeric, 0)::numeric, 4)::numeric as s_score ' \
             f'from "SimRaAPI_osmwayslegs" ' \
-            f"where '{infra_type}' = any(infra_type)" \
+            f"where '{infra_type}' = any(infra_type) " \
             f"and count > 0" \
             f") f;"
 
@@ -113,7 +113,7 @@ def add_columns(cur, conn):
             "add column if not exists s_score numeric," \
             "add column if not exists m_p_score numeric," \
             "add column if not exists danger_score numeric," \
-            "add column if not exists infra_type text[];"
+            "add column if not exists infra_type text[]"
 
     cur.execute(query)
     conn.commit()

--- a/src/app/calculation/scores.py
+++ b/src/app/calculation/scores.py
@@ -1,7 +1,6 @@
 def calculate_scores_legs(leg, cur, conn):
     # annoying cleaning of input strings as sql cant handle some operators (:, $, etc)
-    if "parking" in leg['infra_type']:
-        leg["infra_type"] = "[highway = residential][parking][!cycleway]"
+    leg['infra_type'] = leg['infra_type'].replace("~'^parking:.*$'~'.'", "parking")
     leg['infra_type'] = leg['infra_type'].replace(":", "")
 
     if leg['c_count'] > 0:
@@ -41,9 +40,8 @@ def calculate_scores_legs(leg, cur, conn):
 
 
 def calculate_scores_infra_types(infra_type, cur, conn):
-    if "parking" in infra_type:
-        infra_type = "[highway = residential][parking][!cycleway]"
-    infra_type = infra_type.replace(":", " ")
+    infra_type = infra_type.replace("~'^parking:.*$'~'.'", "parking")
+    infra_type = infra_type.replace(":", "")
 
     query = f'insert into infra_type_scores' \
             f'(infra_type, avg_a_score, avg_c_score, avg_p_score, ' \

--- a/src/app/calculation/scores.py
+++ b/src/app/calculation/scores.py
@@ -84,7 +84,7 @@ def calculate_scores_infra_types(infra_type, cur, conn):
             f'round(greatest(least(1 - (1 / sum(count * (ST_Length(geom::geography)::numeric / 1000))::numeric * (4.4 * sum("scaryIncidentCount")::numeric + sum("normalIncidentCount")::numeric)), 1)::numeric, 0)::numeric, 4)::numeric as s_score ' \
             f'from "SimRaAPI_osmwayslegs" ' \
             f"where '{infra_type}' = any(infra_type) " \
-            f"and count > 0" \
+            f'and count > 0 or "avoidedCount" > 0' \
             f") f;"
 
     cur.execute(query)

--- a/src/app/data/highway.py
+++ b/src/app/data/highway.py
@@ -48,7 +48,25 @@ cycleway = [
                 "['cycleway:both' = shared_lane]"],
         ]
 
-# TODO: Think about adding highway-cycleway combinations
+highway_and_cycleway = [
+            ["[highway = primary][cycleway = track]", "[highway = primary]['cycleway:left' = track]",
+             "[highway = primary]['cycleway:right' = track]", "[highway = primary]['cycleway:both' = track]"],
+            ["[highway = secondary][cycleway = track]", "[highway = secondary]['cycleway:left' = track]",
+             "[highway = secondary]['cycleway:right' = track]", "[highway = secondary]['cycleway:both' = track]"],
+            ["[highway = tertiary][cycleway = track]", "[highway = tertiary]['cycleway:left' = track]",
+             "[highway = tertiary]['cycleway:right' = track]", "[highway = tertiary]['cycleway:both' = track]"],
+            ["[highway = residential][cycleway = track]", "[highway = residential]['cycleway:left' = track]",
+             "[highway = residential]['cycleway:right' = track]", "[highway = residential]['cycleway:both' = track]"],
+
+            ["[highway = primary][cycleway = lane]", "[highway = primary]['cycleway:left' = lane]",
+             "[highway = primary]['cycleway:right' = lane]", "[highway = primary]['cycleway:both' = lane]"],
+            ["[highway = secondary][cycleway = lane]", "[highway = secondary]['cycleway:left' = lane]",
+             "[highway = secondary]['cycleway:right' = lane]", "[highway = secondary]['cycleway:both' = lane]"],
+            ["[highway = tertiary][cycleway = lane]", "[highway = tertiary]['cycleway:left' = lane]",
+             "[highway = tertiary]['cycleway:right' = lane]", "[highway = tertiary]['cycleway:both' = lane]"],
+            ["[highway = residential][cycleway = lane]", "[highway = residential]['cycleway:left' = lane]",
+             "[highway = residential]['cycleway:right' = lane]", "[highway = residential]['cycleway:both' = lane]"],
+        ]
 
 segregated = [
         ["[bicycle = designated][segregated = yes]", "[footway = sidewalk][segregated = yes]"]
@@ -77,6 +95,7 @@ class Highway:
         features = pool.map(Highway.queries, [ (hw, country, city) for hw in segregated ])
         features += pool.map(Highway.queries_no_segregation, [ (hw, country, city) for hw in other ])
         features += pool.map(Highway.queries, [ (hw, country, city) for hw in cycleway ])
+        features += pool.map(Highway.queries, [ (hw, country, city) for hw in highway_and_cycleway ])
         features += pool.map(Highway.queries_no_cycleway, [ (hw, country, city) for hw in parking ])
         features += pool.map(Highway.queries_no_cycleway_no_parking, [ (hw, country, city) for hw in highway ])
 
@@ -96,7 +115,7 @@ class Highway:
             "area[name = " + country + "]->.country; area[name = " + city + "]->.city; "
             "(way" + infra_types + "(area.city)(area.country); "
             "- "
-            "way[~'^segregated:.*$'~'.'](area.city)(area.country););",
+            "way[~'^segregated.*$'~'.'](area.city)(area.country););",
             responseformat="json")
         return {f'{infra_types}[!segregated]': res["elements"]}
 
@@ -111,7 +130,8 @@ class Highway:
             "area[name = " + country + "]->.country; area[name = " + city + "]->.city; "
             "(way" + infra_types + "(area.city)(area.country); "
             "- "
-            "way[~'^cycleway:.*$'~'.'](area.city)(area.country););",
+            "(way[~'^cycleway.*$'~'.'](area.city)(area.country);"
+            "way[~'^cycleway:.*$'~'.'](area.city)(area.country);););",
             responseformat="json")
         return {f'{infra_types}[!cycleway]': res["elements"]}
 
@@ -127,6 +147,7 @@ class Highway:
             "(way" + infra_types + "(area.city)(area.country); "
             "- "
             "(way[~'^cycleway:.*$'~'.'](area.city)(area.country); "
+            "way[~'^cycleway.*$'~'.'](area.city)(area.country);"
             "way[~'^parking:.*$'~'.'](area.city)(area.country);););",
             responseformat="json")
         return {f'{infra_types}[!cycleway][!parking]': res["elements"]}

--- a/src/app/data/highway.py
+++ b/src/app/data/highway.py
@@ -1,5 +1,4 @@
 from multiprocessing import Pool, cpu_count
-from pprint import pprint
 
 import overpass
 
@@ -7,36 +6,37 @@ api = overpass.API(endpoint="https://overpass.kumi.systems/api/interpreter", tim
 
 
 highway = [
-            "[highway = primary]",
-            "[highway = secondary]",
-            "[highway = tertiary]",
+            "[highway = primary]", "[highway = primary][~'^parking:.*$'~'.']",
+            "[highway = secondary]", "[highway = secondary][~'^parking:.*$'~'.']",
+            "[highway = tertiary]", "[highway = tertiary][~'^parking:.*$'~'.']",
             "[highway = unclassified]",
-            "[highway = residential]", "[highway = residential][~'^parking:.*$'~'.'][!cycleway]",
-            "[highway = motorway_link]",
+            "[highway = residential]", "[highway = residential][~'^parking:.*$'~'.']",
             "[highway = primary_link]",
             "[highway = secondary_link]",
             "[highway = tertiary_link]",
-            "[highway = living_street]",
-            "[highway = service]",
+            "[highway = living_street]", "[highway = living_street][~'^parking:.*$'~'.']",
             "[highway = pedestrian]",
             "[highway = track]",
-            "[highway = busway]",
+            "[highway = road]",
             "[highway = footway][bicycle = yes]", "[highway = footway][bicycle = no]", "[highway = footway]",
-            "[highway = bridleway]",
-            "[highway = steps]",
             "[highway = path]",
-            "[footway = sidewalk][bicycle = yes]", "[footway = sidewalk]",
-            "[footway = crossing][bicycle = yes]", "[footway = crossing]",
+            "[footway = sidewalk][bicycle = yes]", "[footway = sidewalk][bicycle = yes][segregated=yes]", "[footway = sidewalk]",
             ["[cycleway = lane]", "['cycleway:left' = lane]", "['cycleway:right' = lane]", "['cycleway:both' = lane]"],
-            ["[cycleway = opposite]", "['cycleway:left' = opposite]", "['cycleway:right' = opposite]", "['cycleway:both' = opposite]"],
+            ["[cycleway = lane][~'^parking:.*$'~'.']", "['cycleway:left' = lane][~'^parking:.*$'~'.']", "['cycleway:right' = lane][~'^parking:.*$'~'.']", "['cycleway:both' = lane][~'^parking:.*$'~'.']"],
+            ["[cycleway = opposite]", "['cycleway:left' = opposite]", "['cycleway:right' = opposite]", "['cycleway:both' = oppposite]"],
+            ["[cycleway = opposite][~'^parking:.*$'~'.']", "['cycleway:left' = opposite][~'^parking:.*$'~'.']", "['cycleway:right' = opposite][~'^parking:.*$'~'.']", "['cycleway:both' = oppposite][~'^parking:.*$'~'.']"],
             ["[cycleway = opposite_lane]", "['cycleway:left' = opposite_lane]", "['cycleway:right' = opposite_lane]", "['cycleway:both' = opposite_lane]"],
-            ["[cycleway = separate]", "['cycleway:left' = separate]", "['cycleway:right' = separate]", "['cycleway:both' = separate]", "[cycleway = track]", "['cycleway:left' = track]", "['cycleway:right' = track]", "['cycleway:both' = track]"],
+            ["[cycleway = track]", "['cycleway:left' = track]", "['cycleway:right' = track]", "['cycleway:both' = track]"],
+            ["[cycleway = track][~'^parking:.*$'~'.']", "['cycleway:left' = track][~'^parking:.*$'~'.']", "['cycleway:right' = track][~'^parking:.*$'~'.']", "['cycleway:both' = track][~'^parking:.*$'~'.']"],
             ["[cycleway = opposite_track]", "['cycleway:left' = opposite_track]", "['cycleway:right' = opposite_track]", "['cycleway:both' = opposite_track]"],
             ["[cycleway = share_busway]", "['cycleway:left' = share_busway]", "['cycleway:right' = share_busway]", "['cycleway:both' = share_busway]"],
+            ["[cycleway = opposite_share_busway]", "['cycleway:left' = opposite_share_busway]", "['cycleway:right' = opposite_share_busway]", "['cycleway:both' = opposite_share_busway]"],
             ["[cycleway = shared_lane]", "['cycleway:left' = shared_lane]", "['cycleway:right' = shared_lane]", "['cycleway:both' = shared_lane]"],
-            "[bicycle = designated]", "[bicycle_road = yes]", "[highway = cycleway]",  # Might have to be put together if overlap is too big
+            "[bicycle = designated]", "[bicycle = designated][~'^parking:.*$'~'.']",
+            "[bicycle_road = yes]", "[bicycle_road = yes][~'^parking:.*$'~'.']",
+            "[highway = cycleway]",
+            "[bicycle = designated][segregated = yes]",
             "[busway = lane]",
-            "[highway = construction]"
         ]
 
 

--- a/src/app/data/highway.py
+++ b/src/app/data/highway.py
@@ -4,38 +4,68 @@ import overpass
 
 api = overpass.API(endpoint="https://overpass.kumi.systems/api/interpreter", timeout=90)
 
-
 highway = [
-            "[highway = primary]", "[highway = primary][~'^parking:.*$'~'.']",
-            "[highway = secondary]", "[highway = secondary][~'^parking:.*$'~'.']",
-            "[highway = tertiary]", "[highway = tertiary][~'^parking:.*$'~'.']",
+            "[highway = primary]",
+            "[highway = secondary]",
+            "[highway = tertiary]",
             "[highway = unclassified]",
-            "[highway = residential]", "[highway = residential][~'^parking:.*$'~'.']",
+            "[highway = residential]",
             "[highway = primary_link]",
             "[highway = secondary_link]",
             "[highway = tertiary_link]",
-            "[highway = living_street]", "[highway = living_street][~'^parking:.*$'~'.']",
+            "[highway = living_street]",
+        ]
+
+parking = [
+            "[highway = primary][~'^parking:.*$'~'.']",
+            "[highway = secondary][~'^parking:.*$'~'.']",
+            "[highway = tertiary][~'^parking:.*$'~'.']",
+            "[highway = residential][~'^parking:.*$'~'.']",
+            "[highway = living_street][~'^parking:.*$'~'.']",
+        ]
+
+cycleway = [
+            ["[cycleway = lane][~'^parking:.*$'~'.']", "['cycleway:left' = lane][~'^parking:.*$'~'.']",
+                "['cycleway:right' = lane][~'^parking:.*$'~'.']", "['cycleway:both' = lane][~'^parking:.*$'~'.']"],
+            ["[cycleway = opposite][~'^parking:.*$'~'.']", "['cycleway:left' = opposite][~'^parking:.*$'~'.']",
+                "['cycleway:right' = opposite][~'^parking:.*$'~'.']", "['cycleway:both' = oppposite][~'^parking:.*$'~'.']"],
+            ["[cycleway = track][~'^parking:.*$'~'.']", "['cycleway:left' = track][~'^parking:.*$'~'.']",
+                "['cycleway:right' = track][~'^parking:.*$'~'.']", "['cycleway:both' = track][~'^parking:.*$'~'.']"],
+
+
+            ["[cycleway = track]", "['cycleway:left' = track]", "['cycleway:right' = track]",
+                "['cycleway:both' = track]"],
+            ["[cycleway = opposite_track]", "['cycleway:left' = opposite_track]", "['cycleway:right' = opposite_track]",
+                "['cycleway:both' = opposite_track]"],
+            ["[cycleway = lane]", "['cycleway:left' = lane]", "['cycleway:right' = lane]", "['cycleway:both' = lane]"],
+            ["[cycleway = opposite]", "['cycleway:left' = opposite]", "['cycleway:right' = opposite]",
+                "['cycleway:both' = oppposite]"],
+            ["[cycleway = share_busway]", "['cycleway:left' = share_busway]", "['cycleway:right' = share_busway]",
+                "['cycleway:both' = share_busway]"],
+            ["[cycleway = opposite_share_busway]", "['cycleway:left' = opposite_share_busway]",
+                "['cycleway:right' = opposite_share_busway]", "['cycleway:both' = opposite_share_busway]"],
+            ["[cycleway = shared_lane]", "['cycleway:left' = shared_lane]", "['cycleway:right' = shared_lane]",
+                "['cycleway:both' = shared_lane]"],
+        ]
+
+# TODO: Think about adding highway-cycleway combinations
+
+segregated = [
+        ["[bicycle = designated][segregated = yes]", "[footway = sidewalk][segregated = yes]"]
+    ]
+
+other = [
+            "[bicycle = designated][~'^parking:.*$'~'.']",
+            "[bicycle_road = yes][~'^parking:.*$'~'.']",
+            "[bicycle_road = yes]",
+            "[highway = cycleway]",
+            "[bicycle = designated]",
             "[highway = pedestrian]",
             "[highway = track]",
             "[highway = road]",
-            "[highway = footway][bicycle = yes]", "[highway = footway][bicycle = no]", "[highway = footway]",
             "[highway = path]",
-            "[footway = sidewalk][bicycle = yes]", "[footway = sidewalk][bicycle = yes][segregated=yes]", "[footway = sidewalk]",
-            ["[cycleway = lane]", "['cycleway:left' = lane]", "['cycleway:right' = lane]", "['cycleway:both' = lane]"],
-            ["[cycleway = lane][~'^parking:.*$'~'.']", "['cycleway:left' = lane][~'^parking:.*$'~'.']", "['cycleway:right' = lane][~'^parking:.*$'~'.']", "['cycleway:both' = lane][~'^parking:.*$'~'.']"],
-            ["[cycleway = opposite]", "['cycleway:left' = opposite]", "['cycleway:right' = opposite]", "['cycleway:both' = oppposite]"],
-            ["[cycleway = opposite][~'^parking:.*$'~'.']", "['cycleway:left' = opposite][~'^parking:.*$'~'.']", "['cycleway:right' = opposite][~'^parking:.*$'~'.']", "['cycleway:both' = oppposite][~'^parking:.*$'~'.']"],
-            ["[cycleway = opposite_lane]", "['cycleway:left' = opposite_lane]", "['cycleway:right' = opposite_lane]", "['cycleway:both' = opposite_lane]"],
-            ["[cycleway = track]", "['cycleway:left' = track]", "['cycleway:right' = track]", "['cycleway:both' = track]"],
-            ["[cycleway = track][~'^parking:.*$'~'.']", "['cycleway:left' = track][~'^parking:.*$'~'.']", "['cycleway:right' = track][~'^parking:.*$'~'.']", "['cycleway:both' = track][~'^parking:.*$'~'.']"],
-            ["[cycleway = opposite_track]", "['cycleway:left' = opposite_track]", "['cycleway:right' = opposite_track]", "['cycleway:both' = opposite_track]"],
-            ["[cycleway = share_busway]", "['cycleway:left' = share_busway]", "['cycleway:right' = share_busway]", "['cycleway:both' = share_busway]"],
-            ["[cycleway = opposite_share_busway]", "['cycleway:left' = opposite_share_busway]", "['cycleway:right' = opposite_share_busway]", "['cycleway:both' = opposite_share_busway]"],
-            ["[cycleway = shared_lane]", "['cycleway:left' = shared_lane]", "['cycleway:right' = shared_lane]", "['cycleway:both' = shared_lane]"],
-            "[bicycle = designated]", "[bicycle = designated][~'^parking:.*$'~'.']",
-            "[bicycle_road = yes]", "[bicycle_road = yes][~'^parking:.*$'~'.']",
-            "[highway = cycleway]",
-            "[bicycle = designated][segregated = yes]",
+            "[footway = sidewalk]",
+            "[highway = footway]",
             "[busway = lane]",
         ]
 
@@ -44,12 +74,62 @@ class Highway:
 
     def query_area(country = "Deutschland", city = "Berlin"):
         pool = Pool(cpu_count())
-        features = pool.map(Highway.queries, [ (hw, country, city) for hw in highway ])
-        
+        features = pool.map(Highway.queries, [ (hw, country, city) for hw in segregated ])
+        features += pool.map(Highway.queries_no_segregation, [ (hw, country, city) for hw in other ])
+        features += pool.map(Highway.queries, [ (hw, country, city) for hw in cycleway ])
+        features += pool.map(Highway.queries_no_cycleway, [ (hw, country, city) for hw in parking ])
+        features += pool.map(Highway.queries_no_cycleway_no_parking, [ (hw, country, city) for hw in highway ])
+
         pool.close()
         pool.join()
 
         return  { "features": features }
+
+    def queries_no_segregation(args):
+        """
+        Removes segregation tags from queries and retrieves the query result
+        """
+        infra_types = args[0]
+        country = args[1]
+        city = args[2]
+        res = api.get(
+            "area[name = " + country + "]->.country; area[name = " + city + "]->.city; "
+            "(way" + infra_types + "(area.city)(area.country); "
+            "- "
+            "way[~'^segregated:.*$'~'.'](area.city)(area.country););",
+            responseformat="json")
+        return {f'{infra_types}[!segregated]': res["elements"]}
+
+    def queries_no_cycleway(args):
+        """
+        Removes cycleway tags from queries and retrieves the query result
+        """
+        infra_types = args[0]
+        country = args[1]
+        city = args[2]
+        res = api.get(
+            "area[name = " + country + "]->.country; area[name = " + city + "]->.city; "
+            "(way" + infra_types + "(area.city)(area.country); "
+            "- "
+            "way[~'^cycleway:.*$'~'.'](area.city)(area.country););",
+            responseformat="json")
+        return {f'{infra_types}[!cycleway]': res["elements"]}
+
+    def queries_no_cycleway_no_parking(args):
+        """
+        Removes cycleway tags from queries and retrieves the query result
+        """
+        infra_types = args[0]
+        country = args[1]
+        city = args[2]
+        res = api.get(
+            "area[name = " + country + "]->.country; area[name = " + city + "]->.city; "
+            "(way" + infra_types + "(area.city)(area.country); "
+            "- "
+            "(way[~'^cycleway:.*$'~'.'](area.city)(area.country); "
+            "way[~'^parking:.*$'~'.'](area.city)(area.country);););",
+            responseformat="json")
+        return {f'{infra_types}[!cycleway][!parking]': res["elements"]}
 
     def queries(args):
         infra_types = args[0]


### PR DESCRIPTION
Added parking to more infra-types for further analysis.

Removed some unnecessary infra-types: 

- footway = crossing -> always grouped together with other types, not really a choice to use (crossings have to be taken)
- motorway_link -> should not be used by cyclists, no reason to look for this
- busway -> does not exist in germany
- bridleway -> designed for horses, not really part of cyclist/commuter routes
- steps
- highway = construction -> we are not looking at historic data so this does not make much sense imo.